### PR TITLE
Adds Cyclic melting recipes to utilize both inv. slots.

### DIFF
--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_black_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_black_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/black"
+  },{
+    "tag": "forge:dyes/black"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_black",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_blue_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_blue_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/blue"
+  },{
+    "tag": "forge:dyes/blue"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_blue",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_brown_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_brown_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/brown"
+  },{
+    "tag": "forge:dyes/brown"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_brown",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_cyan_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_cyan_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/cyan"
+  },{
+    "tag": "forge:dyes/cyan"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_cyan",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_gray_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_gray_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/gray"
+  },{
+    "tag": "forge:dyes/gray"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_gray",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_green_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_green_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/green"
+  },{
+    "tag": "forge:dyes/green"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_green",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_light_blue_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_light_blue_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/light_blue"
+  },{
+    "tag": "forge:dyes/light_blue"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_light_blue",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_light_gray_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_light_gray_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/light_gray"
+  },{
+    "tag": "forge:dyes/light_gray"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_light_gray",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_lime_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_lime_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/lime"
+  },{
+    "tag": "forge:dyes/lime"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_lime",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_magenta_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_magenta_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/magenta"
+  },{
+    "tag": "forge:dyes/magenta"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_magenta",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_none_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_none_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/none"
+  },{
+    "tag": "forge:dyes/none"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_none",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_orange_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_orange_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/orange"
+  },{
+    "tag": "forge:dyes/orange"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_orange",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_pink_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_pink_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/pink"
+  },{
+    "tag": "forge:dyes/pink"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_pink",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_purple_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_purple_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/purple"
+  },{
+    "tag": "forge:dyes/purple"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_purple",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_red_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_red_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/red"
+  },{
+    "tag": "forge:dyes/red"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_red",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_white_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_white_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/white"
+  },{
+    "tag": "forge:dyes/white"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_white",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}

--- a/src/main/resources/data/colouredstuff/recipes/cyclic/melt_yellow_2x.json
+++ b/src/main/resources/data/colouredstuff/recipes/cyclic/melt_yellow_2x.json
@@ -1,0 +1,27 @@
+{
+  "type": "cyclic:melter",
+  "ingredients": [{
+    "tag": "forge:dyes/yellow"
+  },{
+    "tag": "forge:dyes/yellow"
+  }],
+  "result": {
+    "fluid": "colouredstuff:water_yellow",
+    "count": 500
+  },
+	"energy": {
+		"rfpertick": 50,
+		"ticks": 20
+	},
+	"conditions": [
+		{
+			"values": [
+				{
+					"modid": "cyclic",
+					"type": "forge:mod_loaded"
+				}
+			],
+			"type": "forge:and"
+		}
+	]
+}


### PR DESCRIPTION
If there was dye in both input slots the machine wouldn't accept the recipe,  This PR adds those recipes that mimic how Cyclic's own recipes are for using both slots.

1x dye = 250mb
2x dye = 500mb

![image](https://github.com/user-attachments/assets/5fbff65a-572d-4c4d-8f4b-cb73e0cfaf96)
