### PR TITLE
Add coloured buttons to wooden_buttons item tag

### DIFF
--- a/src/main/resources/data/minecraft/tags/items/wooden_buttons.json
+++ b/src/main/resources/data/minecraft/tags/items/wooden_buttons.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "values": [
+
+"colouredstuff:button_planks_black",
+"colouredstuff:button_planks_blue",
+"colouredstuff:button_planks_brown",
+"colouredstuff:button_planks_cyan",
+"colouredstuff:button_planks_gray",
+"colouredstuff:button_planks_green",
+"colouredstuff:button_planks_light_blue",
+"colouredstuff:button_planks_light_gray",
+"colouredstuff:button_planks_lime",
+"colouredstuff:button_planks_magenta",
+"colouredstuff:button_planks_none",
+"colouredstuff:button_planks_orange",
+"colouredstuff:button_planks_pink",
+"colouredstuff:button_planks_purple",
+"colouredstuff:button_planks_red",
+"colouredstuff:button_planks_white",
+"colouredstuff:button_planks_yellow"
+  ]
+}


### PR DESCRIPTION
![Screenshot_20250404_185442](https://github.com/user-attachments/assets/92e82d3f-f416-45f7-9fad-f04692eccf30)

A bug I noticed while playing Sky Factory 5, there might be other tags that should be in both item & block - I didn't audit any others.

The image above shows crafting the doorbell from Cyclic working with this change :^)